### PR TITLE
Added missing export for "inputtypes"

### DIFF
--- a/feature/inputtypes.js
+++ b/feature/inputtypes.js
@@ -40,3 +40,4 @@ Modernizr.inputtypes = _isBrowser && function (props) {
 
   return inputs;
 }(inputtypes);
+export default Modernizr.inputtypes;


### PR DESCRIPTION
There is an export missing for "inputtypes".